### PR TITLE
[PROPOSED] bpo-25658: Omit two API functions

### DIFF
--- a/Include/pythread.h
+++ b/Include/pythread.h
@@ -140,7 +140,6 @@ PyAPI_FUNC(int) PyThread_tss_create(Py_tss_t *key);
 PyAPI_FUNC(void) PyThread_tss_delete(Py_tss_t *key);
 PyAPI_FUNC(int) PyThread_tss_set(Py_tss_t *key, void *value);
 PyAPI_FUNC(void *) PyThread_tss_get(Py_tss_t *key);
-PyAPI_FUNC(void) PyThread_tss_delete_value(Py_tss_t *key);
 
 /* In the limited API, Py_tss_t value must be allocated through a pointer by
    PyThread_tss_alloc, and free by PyThread_tss_free at the life cycle end of

--- a/Include/pythread.h
+++ b/Include/pythread.h
@@ -142,11 +142,6 @@ PyAPI_FUNC(int) PyThread_tss_set(Py_tss_t *key, void *value);
 PyAPI_FUNC(void *) PyThread_tss_get(Py_tss_t *key);
 PyAPI_FUNC(void) PyThread_tss_delete_value(Py_tss_t *key);
 
-#ifndef Py_LIMITED_API
-/* Cleanup after a fork */
-PyAPI_FUNC(void) PyThread_ReInitTSS(void);
-#endif
-
 /* In the limited API, Py_tss_t value must be allocated through a pointer by
    PyThread_tss_alloc, and free by PyThread_tss_free at the life cycle end of
    the CPython interpreter.

--- a/Include/pythread.h
+++ b/Include/pythread.h
@@ -2,6 +2,10 @@
 #ifndef Py_PYTHREAD_H
 #define Py_PYTHREAD_H
 
+#if !(defined(_POSIX_THREADS) || defined(NT_THREADS))
+#   error "Require native thread feature. See https://bugs.python.org/issue30832"
+#endif
+
 #include <stdbool.h>  /* necessary for TSS key */
 
 typedef void *PyThread_type_lock;
@@ -115,9 +119,6 @@ typedef struct _py_tss_t Py_tss_t;
        but hardcode the unsigned long to avoid errors for include directive.
     */
 #   define NATIVE_TSS_KEY_T     unsigned long
-#else
-    /* For the platform that has not supplied native TSS */
-#   define NATIVE_TSS_KEY_T     int
 #endif
 
 /* When Py_LIMITED_API is not defined, the type layout of Py_tss_t is in

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -4183,7 +4183,6 @@ test_pythread_tss_key_state(PyObject *self, PyObject *args)
                                   "preserved after calling " #expr); }
     CHECK_TSS_API(PyThread_tss_set(&tss_key, NULL));
     CHECK_TSS_API(PyThread_tss_get(&tss_key));
-    CHECK_TSS_API(PyThread_tss_delete_value(&tss_key));
 #undef CHECK_TSS_API
     PyThread_tss_delete(&tss_key);
     if (PyThread_tss_is_created(&tss_key)) {

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -450,9 +450,6 @@ void
 PyOS_AfterFork_Child(void)
 {
 #ifdef WITH_THREAD
-    /* PyThread_ReInitTSS() must be called early, to make sure that the TSS API
-     * can be called safely. */
-    PyThread_ReInitTSS();
     _PyGILState_Reinit();
     PyEval_ReInitThreads();
     _PyImport_ReInitLock();

--- a/Modules/xxlimited.c
+++ b/Modules/xxlimited.c
@@ -264,12 +264,6 @@ xx_tss(PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_RuntimeError, "PyThread_tss_get failed");
         return NULL;
     }
-    PyThread_tss_delete_value(tss_key);
-    if (PyThread_tss_get(tss_key) != NULL) {
-        PyThread_tss_free(tss_key);
-        PyErr_SetString(PyExc_RuntimeError, "TSS value is not deleted");
-        return NULL;
-    }
     PyThread_tss_delete(tss_key);
     PyThread_tss_free(tss_key);
     tss_key = NULL;

--- a/PC/python3.def
+++ b/PC/python3.def
@@ -573,7 +573,6 @@ EXPORTS
   PyThread_tss_alloc=python37.PyThread_tss_alloc
   PyThread_tss_create=python37.PyThread_tss_create
   PyThread_tss_delete=python37.PyThread_tss_delete
-  PyThread_tss_delete_value=python37.PyThread_tss_delete_value
   PyThread_tss_free=python37.PyThread_tss_free
   PyThread_tss_get=python37.PyThread_tss_get
   PyThread_tss_is_created=python37.PyThread_tss_is_created

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -502,7 +502,7 @@ PyThreadState_Delete(PyThreadState *tstate)
         Py_FatalError("PyThreadState_Delete: tstate is still current");
 #ifdef WITH_THREAD
     if (autoInterpreterState && PyThread_tss_get(&autoTSSkey) == tstate) {
-        PyThread_tss_delete_value(&autoTSSkey);
+        PyThread_tss_set(&autoTSSkey, NULL);
     }
 #endif /* WITH_THREAD */
     tstate_delete_common(tstate);
@@ -519,7 +519,7 @@ PyThreadState_DeleteCurrent()
             "PyThreadState_DeleteCurrent: no current tstate");
     tstate_delete_common(tstate);
     if (autoInterpreterState && PyThread_tss_get(&autoTSSkey) == tstate) {
-        PyThread_tss_delete_value(&autoTSSkey);
+        PyThread_tss_set(&autoTSSkey, NULL);
     }
     SET_TSTATE(NULL);
     PyEval_ReleaseLock();

--- a/Python/thread.c
+++ b/Python/thread.c
@@ -131,7 +131,7 @@ Use PyThread_tss_get(&thekey) to retrieve the void* value associated
 with thekey in the current thread.  This returns NULL if no value is
 associated with thekey in the current thread.
 
-Use PyThread_tss_delete_value(&thekey) to forget the current thread's associated
+Use PyThread_tss_set(&thekey, NULL) to forget the current thread's associated
 value for thekey.  PyThread_tss_delete(&thekey) forgets the values associated
 with thekey across *all* threads.
 

--- a/Python/thread_nt.h
+++ b/Python/thread_nt.h
@@ -466,12 +466,3 @@ PyThread_tss_get(Py_tss_t *key)
     SetLastError(error);
     return result;
 }
-
-void
-PyThread_tss_delete_value(Py_tss_t *key)
-{
-    /* NULL is used as "key missing", and it is also the default
-     * given by TlsGetValue() if nothing has been set yet.
-     */
-    TlsSetValue(key->_key, NULL);
-}

--- a/Python/thread_nt.h
+++ b/Python/thread_nt.h
@@ -475,12 +475,3 @@ PyThread_tss_delete_value(Py_tss_t *key)
      */
     TlsSetValue(key->_key, NULL);
 }
-
-
-/* reinitialization of TSS is not necessary after fork when using
- * the native TLS functions.  And forking isn't supported on Windows either.
- */
-void
-PyThread_ReInitTSS(void)
-{
-}

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -737,9 +737,3 @@ PyThread_tss_delete_value(Py_tss_t *key)
 {
     pthread_setspecific(key->_key, NULL);
 }
-
-
-void
-PyThread_ReInitTSS(void)
-{
-}

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -731,9 +731,3 @@ PyThread_tss_get(Py_tss_t *key)
 {
     return pthread_getspecific(key->_key);
 }
-
-void
-PyThread_tss_delete_value(Py_tss_t *key)
-{
-    pthread_setspecific(key->_key, NULL);
-}


### PR DESCRIPTION
This is a draft which proposed updates that will be appended to the opened [PR 1362][pr1362].

https://bugs.python.org/issue25658
https://www.python.org/dev/peps/pep-0539/

#### Highlight of changes

- bpo-25658: Omit PyThread_ReInitTSS function
- bpo-25658: Omit PyThread_tss_delete_value function

These functions have handled memory deallocation to key-value storage on the own implementation, but  currently the own implementation is gone (aa0aa04). It means: (1) `PyThread_ReInitTSS` makes to be no-op for all supported platforms (Windows and pthreads); likewise (2) `PyThread_tss_delete_value` just does to empty the storage (i.e. `"PyThread_tss_delete_value(key)"`  makes to be equal to `"PyThread_tss_set(key, NULL)"`).
We (or at least I) won't get back to the own implementation, therefore, I suggest to omit these functions for new TSS API.

[pr1362]: https://github.com/python/cpython/pull/1362
